### PR TITLE
Allow to specify the table name and use connection.release

### DIFF
--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -23,7 +23,7 @@ module.exports = function (connect) {
                     connection.query('CREATE EVENT IF NOT EXISTS `sess_cleanup` ON SCHEDULE EVERY 15 MINUTE DO DELETE FROM `' + TableName + '` WHERE `expires` < UNIX_TIMESTAMP()');
                     connection.query('SET GLOBAL event_scheduler = 1');
                 }
-                if (pool) connection.end();
+                if (pool) connection.release();
             });
         }
 
@@ -50,7 +50,7 @@ module.exports = function (connect) {
                 } else {
                     callback(err);
                 }
-                if (pool) connection.end();
+                if (pool) connection.release();
             }).on('error', function (err) {
                     callback(err);
                 });
@@ -71,7 +71,7 @@ module.exports = function (connect) {
         var query = function(connection, pool) {
             connection.query('INSERT INTO `' + TableName + '` (`sid`, `session`, `expires`) VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE `session` = ?, `expires` = ?', [sid, session, expires, session, expires], function (err) {
                 callback(err);
-                if (pool) connection.end();
+                if (pool) connection.release();
             });
         }
         if (this.pool) {
@@ -88,7 +88,7 @@ module.exports = function (connect) {
         var query = function(connection, pool) {
             connection.query('DELETE FROM `' + TableName + '` WHERE `sid` = ?', [sid], function (err) {
                 callback(err);
-                if (pool) connection.end();
+                if (pool) connection.release();
             });
         }
         if (this.pool) {


### PR DESCRIPTION
Allow to specify the table name in the options is required but keep the default to 'sessions'.
Use connection.release() as specified in the new node-mysql version.
