### PR TITLE
Defines connection for pool connection release

### DIFF
--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -1,7 +1,7 @@
 /*
  Author: Nathan LaFreniere <nlf@andyet.net>
  Homepage: https://github.com/nlf/connect-mysql
- 
+
  MySQL pool support: Anton Skshidlevsky <meefik@gmail.com>
  Homepage: https://github.com/meefik/connect-mysql
  */
@@ -23,7 +23,7 @@ module.exports = function (connect) {
         var nodeCleanup = function() {
             this.query(function(connection, release) {
                 connection.query(cleanupQuery);
-                release();
+                release(connection);
             });
         }.bind(this);
         this.query(function(connection, release) {
@@ -39,7 +39,7 @@ module.exports = function (connect) {
                         }
                     });
                 }
-                release();
+                release(connection);
             });
         });
     }
@@ -48,7 +48,7 @@ module.exports = function (connect) {
 
     MySQLStore.prototype.query = function(query) {
         var pool = this.pool;
-        var release = function() {
+        var release = function(connection) {
             if (pool) connection.release();
         }
         if (pool) {
@@ -69,7 +69,7 @@ module.exports = function (connect) {
                 } else {
                     callback(err);
                 }
-                release();
+                release(connection);
             }).on('error', function (err) {
                 callback(err);
             });
@@ -82,7 +82,7 @@ module.exports = function (connect) {
         this.query(function(connection, release) {
             connection.query('INSERT INTO `' + TableName + '` (`sid`, `session`, `expires`) VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE `session` = ?, `expires` = ?', [sid, session, expires, session, expires], function (err) {
                 callback(err);
-                release();
+                release(connection);
             });
         });
     };
@@ -91,7 +91,7 @@ module.exports = function (connect) {
         this.query(function(connection, release) {
             connection.query('DELETE FROM `' + TableName + '` WHERE `sid` = ?', [sid], function (err) {
                 callback(err);
-                release();
+                release(connection);
             });
         });
     };


### PR DESCRIPTION
When this library is used with a connection pool within a node.js app, the error message "ReferenceError: connection is not defined" appears when the app is started.  This minor change corrects that.  Have successfully tested with both pool and non-pool connection types.
