### PR TITLE
Explicit disconnect handling on connection pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To use session encryption:
 * `config`: the configuration that will be passed to `createConnection()` or `createPool()` if pool is `true`
 * `cleanup`: a boolean specifying whether to enable the cleanup events. note that if this is disabled, cleanup will not take place at all and should be done externally.
 * `secret`: key that will be used to encrypt session data.  If this option is not provided then data will be stored in plain text
-* `algorithm`: the algorithm that should be used to encrypt session data.  Defaults to `'aes-256-ctr'` 
+* `algorithm`: the algorithm that should be used to encrypt session data.  Defaults to `'aes-256-ctr'`
 
 -----
 License: MIT

--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -22,7 +22,8 @@ module.exports = function (connect) {
         if (options.hasOwnProperty('table')) TableName = options.table;
         if (options.hasOwnProperty('secret')) this.crypto = require('crypto'), this.secret = options.secret;
         if (options.hasOwnProperty('algorithm')) this.algorithm = options.algorithm;
-        if(options.hasOwnProperty('pool')) {
+        if (options.hasOwnProperty('retries')) this.numRetries = options.retries;
+        if (options.hasOwnProperty('pool')) {
             var pool = options.pool;
             if(isFunction(pool.getConnection)) {
                 this.usePool = true;
@@ -37,32 +38,34 @@ module.exports = function (connect) {
 
         var cleanupQuery = 'DELETE FROM `' + TableName + '` WHERE `expires` < UNIX_TIMESTAMP()';
         var nodeCleanup = function() {
-            this.query(function(connection, release) {
-                connection.query(cleanupQuery);
-                release(connection);
-            });
+            this.query(function(connection, done) {
+                connection.query(cleanupQuery, function(err) {
+                    done(err);
+                });
+            }, function noop() { });
         }.bind(this);
 
-        this.query(function(connection, release) {
+        this.query(function(connection, done) {
             connection.query('CREATE TABLE IF NOT EXISTS `' + TableName + '` (`sid` VARCHAR(255) NOT NULL, `session` TEXT NOT NULL, `expires` INT, PRIMARY KEY (`sid`) ) CHARACTER SET utf8 COLLATE utf8_unicode_ci', function (err) {
-                if (err) throw err;
-                if (cleanup) {
+                if (err) done(err);
+                else if (cleanup) {
                     connection.query('SET GLOBAL event_scheduler = 1', function(err) {
                         if (err) {
-                            if (err.code !== 'ER_SPECIFIC_ACCESS_DENIED_ERROR') throw err;
-                            setInterval(nodeCleanup, 900000);
-                            release(connection);
+                            if (err.code !== 'ER_SPECIFIC_ACCESS_DENIED_ERROR') done(err);
+                            else {
+                                setInterval(nodeCleanup, 900000);
+                                done();
+                            }
                         } else {
                             connection.query('CREATE EVENT IF NOT EXISTS `sess_cleanup` ON SCHEDULE EVERY 15 MINUTE DO ' + cleanupQuery, function(err) {
-                                release(connection);
+                                done(err);
                             });
                         }
                     });
-                } else {
-                    release(connection);
                 }
+                else done();
             });
-        });
+        }, function(err) { if(err) throw err; });
     }
 
     util.inherits(MySQLStore, Store);
@@ -100,59 +103,90 @@ module.exports = function (connect) {
         }
     });
 
-    MySQLStore.prototype.query = function(query) {
+    MySQLStore.prototype.query = function(query, callback) {
         var usePool = this.usePool,
+            pool = this.pool,
+            retries = 0,
+            maxRetries = this.numRetries || 3,
             release = function(connection) {
-                if (usePool) connection.release();
-                else connection.end();
+                return function(err, value) {
+                    connection.removeAllListeners('error');
+                    if(err) callback(err);
+                    else {
+                        if (usePool) connection.release();
+                        else connection.end();
+                        callback(null, value);
+                    }
+                };
+            },
+            execute = function(connection) {
+                connection.on('error', function(err) {
+                    if(err.code === 'PROTOCOL_CONNECTION_LOST') {
+                        connection.release();
+                        if(retries < maxRetries) {
+                            retries++;
+                            retry();
+                        }
+                        else callback(err);
+                    }
+                    else callback(err);
+                });
+
+                query(connection, release(connection));
+            },
+            retry = function() {
+                if(usePool) {
+                    pool.getConnection(function(err, connection) {
+                        if(err) callback(err);
+                        else execute(connection);
+                    });
+                }
+                else {
+                    var connection = this.mysql.createConnection(this.config);
+                    connection.connect(function(err) {
+                        if(err) callback(err);
+                        else execute(connection);
+                    });
+                }
             };
 
-        if(usePool) {
-            this.pool.getConnection(function(err, connection) {
-                if (err) throw err;
-                query(connection, release);
-            });
-        }
-        else {
-            var conn = this.mysql.createConnection(this.config);
-            query(conn, release);
-        }
+        retry();
     };
 
     MySQLStore.prototype.get = function (sid, callback) {
         secret = this.secret, self = this;
-        this.query(function(connection, release) {
+        this.query(function(connection, done) {
             connection.query('SELECT `session` FROM `' + TableName + '` WHERE `sid` = ?', [sid], function (err, result) {
                 if (result && result[0] && result[0].session) {
-                    callback(null, JSON.parse((secret) ? decryptData.call(self, result[0].session) : result[0].session));
+                    try {
+                        done(null, JSON.parse((secret) ? decryptData.call(self, result[0].session) : result[0].session));
+                    }
+                    catch(cryptoErr) {
+                        done(cryptoErr);
+                    }
                 } else {
-                    callback(err);
+                    done(err);
                 }
-                release(connection);
-            }).on('error', function (err) {
-                callback(err);
             });
-        });
+        }, callback);
     };
 
     MySQLStore.prototype.set = function (sid, session, callback) {
         var expires = new Date(session.cookie.expires).getTime() / 1000;
         session = JSON.stringify((this.secret) ? encryptData.call(this, JSON.stringify(session), this.secret, this.algorithm) : session);
-        this.query(function(connection, release) {
+        this.query(function(connection, done) {
             connection.query('INSERT INTO `' + TableName + '` (`sid`, `session`, `expires`) VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE `session` = ?, `expires` = ?', [sid, session, expires, session, expires], function (err) {
-                callback(err);
-                release(connection);
+                done(err);
             });
-        });
+        }, callback);
     };
 
     MySQLStore.prototype.destroy = function (sid, callback) {
-        this.query(function(connection, release) {
+        this.query(function(connection, done) {
             connection.query('DELETE FROM `' + TableName + '` WHERE `sid` = ?', [sid], function (err) {
-                callback(err);
-                release(connection);
+                done(err);
             });
-        });
+        }, callback);
     };
 
     function encryptData(plaintext){

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Nathan LaFreniere <nlf@andyet.net>",
   "name": "connect-mysql",
   "description": "a MySQL session store for connect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/nlf/connect-mysql",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update to the node-mysql@2.x compatibility to resolve an issue with the pool connections being terminated by the database.  The system now captures `PROTOCOL_CONNECTION_LOST` errors and attempts to retry the connection up to `retries` times before reporting an error to the controlling session middleware.

This required a rewrite to push most errors back to the session middleware callbacks.  Transport failures on connect like `ENOTFOUND` or `EADDRINUSE` are still thrown as uncaught exceptions, as node-mysql does not capture them.

This patch seems to have worked, but I didn't use a test suite to verify.
