### PR TITLE
fix missing json decoding when omitting secret

### DIFF
--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -40,7 +40,7 @@ function decryptData(ciphertext, secret) {
     throw 'Encrypted session was tampered with!';
   }
 
-  return JSON.parse(obj.pt);
+  return obj.pt;
 }
 
 
@@ -298,6 +298,8 @@ module.exports = function(connect) {
               if (secret) {
                 session = decryptData(session, secret, this.algo);
               }
+              
+              session = JSON.parse(session);
 
               done(null, session);
             } catch (cryptoErr) {


### PR DESCRIPTION
This fixes an issue, wenn I omit the secret and the store data doesn't get json decoded.

This may be a security issue but is quite useful for development/debugging, so it's a nice feature.