### PR TITLE
Handle sessions stored from pre-v2.2 (warn and discard); closes https://github.com/nlf/connect-mysql/issues/47

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This is a simple MySQL backed session store for connect.
 
 It uses the [node-mysql](https://github.com/felixge/node-mysql) module already installed in your project to establish and pool connections.
 
+## Upgrading
+
+Changes introduced in v2.2 mean sessions stored in earlier versions are not backwards compatible with v2.2.
+It it recommended that you clear the session table; alternately sessions will be discarded with a warning message.
+
 ## Options
 
 * `table`: the name of the database table that should be used for storing sessions. Defaults to `'sessions'`

--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -43,8 +43,14 @@ function encryptData(plaintext, secret, algorithm, hashing, encodeas) {
  * Wrapper to extract digest, verify digest & decrypt cipher text
  */
 function decryptData(ciphertext, secret, algorithm, hashing, encodeas) {
-  if (ciphertext)
-    ciphertext = JSON.parse(ciphertext);
+  if (ciphertext) {
+    try {
+      ciphertext = JSON.parse(ciphertext);
+    } catch(e) {
+      console.warn('WARNING: Discarding bad (possibly mysql-connect pre-v2.2) session data', ciphertext);
+      return null;
+    }
+  }
 
   var hmac = digest(secret, ciphertext.ct, hashing, encodeas);
 
@@ -352,9 +358,12 @@ module.exports = function(connect) {
                                    self.encodeas);
               }
               
-              var session = JSON.parse(data);
-
-              done(null, session);
+              if(data) {
+                var session = JSON.parse(data);
+                done(null, session);
+              } else {
+                done(null);
+              }
             } catch (cryptoErr) {
               done(cryptoErr);
             }


### PR DESCRIPTION
Catch JSON parse exception, log warning including content, and discard (treat as session not found / new session).