### PR TITLE
Correct session cleanup query (sid <> id)

### DIFF
--- a/lib/connect-mysql.js
+++ b/lib/connect-mysql.js
@@ -205,9 +205,9 @@ module.exports = function(connect) {
       setInterval(keepAlive, heartbeat);
     }
 
-    var cleanupQuery = 'DELETE FROM `' + TableName + '` WHERE id IN (' +
-      'SELECT temp.id FROM (' +
-        'SELECT `id` FROM `' + TableName + '` WHERE `expires` > 0 AND `expires` < UNIX_TIMESTAMP()' +
+    var cleanupQuery = 'DELETE FROM `' + TableName + '` WHERE sid IN (' +
+      'SELECT temp.sid FROM (' +
+        'SELECT `sid` FROM `' + TableName + '` WHERE `expires` > 0 AND `expires` < UNIX_TIMESTAMP()' +
       ') AS temp' +
     ');'
 


### PR DESCRIPTION
The cleanup query referenced the primary key as `id` rather than `sid`. Closes https://github.com/nlf/connect-mysql/issues/51.